### PR TITLE
[Feature] Prohibit version file edits in feature PRs

### DIFF
--- a/.claude/doc-advisor/toc/rules/.toc_checksums.yaml
+++ b/.claude/doc-advisor/toc/rules/.toc_checksums.yaml
@@ -1,10 +1,10 @@
-# Auto-generated checksum file
+# Phase 1 snapshot - used to replace .toc_checksums.yaml after merge
 # Auto-generated - do not edit
-generated_at: 2026-04-07T12:29:43Z
+generated_at: 2026-04-29T07:13:21Z
 file_count: 5
 checksums:
   docs/rules/cli_output_formatting.md: 0136a2118c9e73169ddd91e1fb9d1a0bcfca85c698fa2587b9b0330db27a6fcf
   docs/rules/document_writing_rules.md: 36bd583a38eb4815686c06a6182996efc6cb2e87e50d5518cda892be36f1e797
-  docs/rules/implementation_guidelines.md: 40e2f4c79e06dd7014ea4d6913de6756c2d682795ca6f373224fffb09311f41a
-  docs/rules/skill_authoring_notes.md: e43d4511d42025b006121bda070cca689db1ae6f2d4d038007d2a8b8f1369e04
-  docs/rules/version_migration_design.md: 0aa727f8e02a1a57d7fc831b5d979ba0d75333cdcbc36db950c6527ef35ce310
+  docs/rules/implementation_guidelines.md: ac304b14c8cfd28a29eb6832f1131036bf71f43adffd8c7a7285803a925ce63e
+  docs/rules/skill_authoring_notes.md: f1a0c98bb338b3154d1a06c5df8c9abce94ad6f890f3a301789464952ed494fb
+  docs/rules/version_migration_design.md: b23a7f63df8a8af24cc2adcb44d1a5cde2e080e31eeb1caf9d1bc09926164044

--- a/.claude/doc-advisor/toc/rules/rules_toc.yaml
+++ b/.claude/doc-advisor/toc/rules/rules_toc.yaml
@@ -4,7 +4,7 @@
 
 metadata:
   name: Development Document Search Index
-  generated_at: 2026-04-07T12:29:43Z
+  generated_at: 2026-04-29T07:13:52Z
   file_count: 5
 
 docs:
@@ -66,91 +66,90 @@ docs:
   docs/rules/implementation_guidelines.md:
     doc_type: rule
     title: Implementation Guidelines
-    purpose: Defines rules for script language selection, testing requirements, and code organization for plugins and skills
+    purpose: Defines rules for plugin script selection, testing requirements, skill documentation practices, code cleanup, parsing approaches, and version management workflow
     content_details:
-      - Script language selection by task type
-      - Python standard library only constraint
-      - Test requirements for plugins and skills
-      - Test file organization in tests/ directory
-      - Prohibition of inline scripts in SKILL.md
-      - External script placement in plugins/{plugin}/skills or plugins/{plugin}/scripts
-      - Removal of unused code
-      - AI interpretation of user input without parsers
+      - Script language selection criteria (Python for data transformation, Bash for external commands)
+      - Mandatory test requirements for plugins/scripts
+      - No inline scripts in SKILL.md (use external script files)
+      - Unused code deletion policy
+      - Avoid rigid parsers for natural language input
+      - Version-related files editing prohibition and update-version workflow
+      - Script placement conventions (skill-specific vs plugin-wide)
     applicable_tasks:
-      - Script development
-      - Plugin implementation
-      - SKILL.md authoring
-      - Code review
-      - Test design
+      - Plugin script implementation
+      - SKILL documentation creation
+      - Code review (testing compliance)
+      - Script architecture review
+      - Version update management
+      - Test suite organization
     keywords:
-      - script language
+      - SKILL.md
       - Python
       - Bash
-      - testing
-      - SKILL.md
-      - inline scripts
-      - plugin structure
+      - test mandatory
+      - script placement
+      - version management
+      - CHANGELOG
+      - unittest
+      - no inline code
   docs/rules/skill_authoring_notes.md:
     doc_type: rule
     title: SKILL.md Authoring Notes
-    purpose: Defines frontmatter configuration, skill invocation settings, code organization, and mandatory guidelines for Claude Code plugin skill development
+    purpose: Defines guidelines and best practices for creating and editing Claude Code plugin SKILL.md files, including frontmatter fields, argument handling, directory structure, and mandatory user interaction patterns
     content_details:
-      - frontmatter fields and their usage
-      - user-invocable vs disable-model-invocation settings
-      - description writing guidelines
-      - argument variables (, /bin/zsh, )
-      - available variables (CLAUDE_PLUGIN_ROOT, CLAUDE_SKILL_DIR, CLAUDE_SESSION_ID)
-      - inter-skill invocation patterns
-      - directory structure conventions
-      - SKILL.md splitting criteria
-      - AskUserQuestion mandatory requirement for user interaction
-      - project-specific coding conventions
+      - frontmatter fields (name, description, user-invocable, disable-model-invocation, allowed-tools, context, agent)
+      - description writing guidelines for auto-invocation triggering
+      - argument variables ($ARGUMENTS, $0, $1, $2)
+      - plugin variables (${CLAUDE_PLUGIN_ROOT}, ${CLAUDE_SKILL_DIR}, ${CLAUDE_SESSION_ID})
+      - cross-skill invocation patterns
+      - directory structure and SKILL.md organization
+      - SKILL.md splitting criteria for external references
+      - AskUserQuestion tool requirement for user interaction
+      - project-specific conventions (Japanese comments, user-invocable rules, path references, MANDATORY markers)
     applicable_tasks:
-      - SKILL.md creation
-      - SKILL.md editing
-      - AI skill authoring
-      - Plugin scaffold setup
-      - Skill invocation decision review
-      - Code organization planning
+      - SKILL.md creation and editing
+      - plugin skill development
+      - skill parameter design
+      - user interaction implementation
+      - multi-skill workflow design
     keywords:
       - SKILL.md
       - frontmatter
+      - description
       - user-invocable
+      - disable-model-invocation
+      - argument
+      - variables
       - AskUserQuestion
-      - MANDATORY
-      - Claude plugin
-      - skill authoring
-      - argument variables
-      - plugin convention
   docs/rules/version_migration_design.md:
     doc_type: rule
-    title: Version Migration Design Rules
-    purpose: Defines version migration design principles, patterns, and implementation strategies for safely handling data transformations across version upgrades
+    title: Version Migration Design Rule
+    purpose: Defines pipeline design principle, idempotency, and version management best practices for safe multi-version data migration and schema evolution
     content_details:
       - Pipeline principle for multi-stage migrations
-      - "Anti-patterns: reading old data directly and fixed old_data in loops"
-      - Single Source of Truth for version numbers with self-describing data
-      - Idempotency principle for safe re-application
+      - Idempotency requirement for re-executable migrations
+      - Version number single source of truth management
       - Forward compatibility by preserving unknown keys
       - Migration history persistence
-      - YAML/JSON configuration migration patterns
-      - Swift Codable/PropertyList versioned struct pattern
-      - Database migration with schema_migrations tracking table
-      - Version skipping strategy for multi-stage jumps
+      - YAML/JSON configuration migration pattern
+      - Swift Codable versioned struct pattern
+      - Database migration file sequencing
+      - Multi-version skipping (e.g., v4 to v6)
+      - Release checklist with testing requirements
     applicable_tasks:
-      - Version upgrade planning
-      - Data migration implementation
-      - Schema design for version management
-      - Migration testing strategy
+      - Version upgrade implementation
+      - Database schema migration design
+      - Legacy data transformation
       - Backward compatibility design
-      - Database schema evolution
+      - Configuration file upgrade
+      - Multi-version data handling
+      - Migration testing and validation
     keywords:
       - migration
-      - version management
-      - pipeline principle
+      - pipeline
       - idempotency
-      - Single Source of Truth
+      - version management
+      - single source of truth
       - forward compatibility
       - schema evolution
-      - Codable
-      - PropertyList
+      - data transformation

--- a/docs/rules/implementation_guidelines.md
+++ b/docs/rules/implementation_guidelines.md
@@ -111,3 +111,48 @@ SKILL.md からの参照には `${CLAUDE_SKILL_DIR}` または `${CLAUDE_PLUGIN_
 - スクリプトは構造化データ（YAML/JSON）の処理に限定する
 - 引数が不足・曖昧な場合は AskUserQuestion で補完する
 - コマンド構文は SKILL.md に記載し、AI がそれを参照して意図を汲み取る
+
+---
+
+## バージョン関連ファイルの編集禁止 [MANDATORY]
+
+feature PR / fix PR / refactor PR 等の通常の作業 PR で、バージョン関連ファイルを編集してはならない。
+バージョン更新の単一責任は `/forge:update-version` にあり、AI および開発者が個別 PR で先回りバンプしてはならない。
+
+### 編集禁止対象
+
+| 対象                                        | 内容                                              |
+| ------------------------------------------- | ------------------------------------------------- |
+| `plugins/*/.claude-plugin/plugin.json`      | 各プラグインの `version` フィールド               |
+| `.claude-plugin/marketplace.json`           | 各プラグインエントリの `version` フィールド       |
+| `README.md` / `README_ja.md` のバージョン表 | プラグインバージョン記載行（数値変更を伴う diff） |
+| `CHANGELOG.md` 等の変更履歴ファイル         | 全エントリ（追加・修正・削除いずれも禁止）        |
+| git tag（`v*` / `<plugin>-v*`）             | 作成・移動・削除いずれも禁止                      |
+
+### 例外
+
+以下に限り編集してよい:
+
+- 新規プラグイン追加時の初期値記述（`0.0.1` 等の新規エントリ作成。既存値の変更ではないため）
+- `/forge:update-version` を明示起動した場合（唯一の正規ルート）
+- 本ルール文書自体の改訂
+
+### 唯一の正規ルート
+
+バージョン更新は `/forge:update-version` のみが担う:
+
+- Step 3.5: `current > main` 検出時に二重バンプ確認 → **1 リリース = 1 バンプ**
+- Step 5: git log から CHANGELOG エントリを自動生成 → PR ごとの CHANGELOG 編集は二重作業 + 競合源
+
+詳細は `docs/specs/forge/design/DES-023_version_management_workflow_design.md` を参照。
+
+### 理由
+
+| 理由                           | 説明                                                                    |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| リリース単位の一意性           | 誰がいつ何をまとめてリリースするかを `/forge:update-version` に集約する |
+| CHANGELOG 自動生成との衝突回避 | git log 由来の自動生成と手動編集が二重化すると整合性が崩れる            |
+| 並行 PR の merge conflict 回避 | 複数 PR が同時に同じ version 行を編集すると衝突が頻発する               |
+
+**NEVER** feat / fix / chore コミットの流れで AI が自発的にバージョンをバンプしてはならない。
+**MUST** バージョン更新が必要と判断したら、ユーザーに `/forge:update-version` の明示起動を提案する。


### PR DESCRIPTION
## 概要

- `docs/rules/implementation_guidelines.md` に「バージョン関連ファイルの編集禁止 [MANDATORY]」セクションを追加し、feature / fix / refactor PR で AI または開発者が version files を自発的に編集することを禁止する
- `.claude/doc-advisor/toc/rules/rules_toc.yaml` を再生成し、新セクションを ToC に反映する
- 提案内容 2（`/anvil:create-pr` Phase 2 の差分検査ステップ追加）はユーザー判断で本 PR では外す（別 Issue 化）

## 背景

PR #27 で AI が自発的に `plugin.json` のバージョンをバンプするケースが発生した。`/forge:update-version` がバージョン更新の単一責任を持つ設計（1 リリース = 1 バンプ、CHANGELOG は git log から自動生成）であるにもかかわらず、明示禁止のルールが存在しないために AI のパターン補完で「feat コミット → リリースっぽい → version も上げる」という短絡が起きていた。リリース管理の単位（誰がいつ何をまとめてリリースするか）が壊れる懸念から、ルール文書として明文化する。

詳細は #28 を参照。

## やったこと

- `docs/rules/implementation_guidelines.md` 末尾に新セクションを追加
  - 編集禁止対象（plugin.json / marketplace.json / README バージョン表 / CHANGELOG / git tag）
  - 例外（新規プラグイン追加時の初期値、`/forge:update-version` 明示起動、本ルール改訂）
  - 唯一の正規ルート（`/forge:update-version` のみ）
  - 理由（リリース単位の一意性 / CHANGELOG 自動生成との衝突 / 並行 PR の merge conflict 回避）
- `.claude/doc-advisor/toc/rules/rules_toc.yaml` を `/doc-advisor:create-rules-toc` で再生成
- `dprint fmt` で書式を整える
- 全テスト（1571 件）が pass することを確認

## やらないこと（このプルリクエストのスコープ外とすること）

- `/anvil:create-pr` Phase 2 への version files 差分検査ステップ追加（ユーザー判断で外す。別 Issue 化）
- 各 SKILL 本文へのルール参照1行追加（コンテキスト汚染回避のため意図的に行わない）
- `/forge:update-version` 改修（`BREAKING:` 対応等。別 Issue）
- CI / pre-commit による自動 enforcement（別 Issue）
- 既存 PR の遡及修正

## 画面設計書

なし（rules 文書のみの変更）

## デザイン仕様書

なし

## API仕様書

なし

## レビュー観点

- 追加セクションの内容が `/forge:update-version` の責任範囲（1 リリース = 1 バンプ、CHANGELOG 自動生成）と整合しているか
- 例外条件（新規プラグイン追加・本ルール改訂）が明確か
- `document_writing_rules.md` の規約（`[MANDATORY]` タグ位置・英語強調 `**NEVER**` / `**MUST**`・長音省略・5列以内表）に準拠しているか
- ToC エントリ（`docs/rules/implementation_guidelines.md`）の `purpose` / `keywords` に version 管理が反映されているか

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- ~~Lv1: ぱっとみて違和感がないかチェックしてAcceptする~~
- Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## スクリーンショット

なし

## 備考

Closes #28
