### PR TITLE
[Fix] get_version_status.py の scope/exclude スカラー形式パースバグを修正

### DIFF
--- a/plugins/forge/scripts/get_version_status.py
+++ b/plugins/forge/scripts/get_version_status.py
@@ -172,7 +172,16 @@ def _parse_version_config_yaml(content):
                     # スカラーキー: サブリストモードを抜けて key:value 取得
                     sublist_mode = None
                     key, _, val = content.partition(":")
-                    current_target[key.strip()] = _strip_quotes(val)
+                    key = key.strip()
+                    val = _strip_quotes(val)
+                    if key in ("scope", "exclude"):
+                        # `scope: "glob/**"` のような同一行スカラー形式も、
+                        # リスト形式（`scope:\n  - ...`）と同じ単一要素リストとして扱う。
+                        # そうしないと match_any_pattern が文字列を1文字ずつ
+                        # パターンとしてイテレートし、常に不一致になる。
+                        current_target[key] = [val] if val else []
+                    else:
+                        current_target[key] = val
             elif indent == 6 and current_target is not None:
                 if sublist_mode == "sync_files" and content.startswith("- path:"):
                     current_sync = {"path": _strip_quotes(content.split(":", 1)[1])}

--- a/plugins/forge/skills/update-version/SKILL.md
+++ b/plugins/forge/skills/update-version/SKILL.md
@@ -74,7 +74,7 @@ target が引数で明示指定されていない場合のみ実行する。
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/get_version_status.py
 ```
 
-`summary.needs_bump` は「`scope` に一致する変更ファイルがあり、かつまだ version が更新されていない target」の配列。各 target に `.version-config.yaml` の `scope:`（glob、例: `plugins/forge/**`）が定義されている必要がある。
+`summary.needs_bump` は「`scope` に一致する変更ファイルがあり、かつまだ version が更新されていない target」の配列。各 target に `.version-config.yaml` の `scope:`（glob、例: `plugins/forge/**`）が定義されている必要がある。`scope:` / `exclude:` はリスト形式（`scope:\n  - "..."`）・単一行スカラー形式（`scope: "..."`）のどちらでも解釈される。
 
 | `needs_bump` の状態 | 挙動                                                                                                        |
 | ------------------- | ----------------------------------------------------------------------------------------------------------- |

--- a/tests/forge/scripts/test_get_version_status.py
+++ b/tests/forge/scripts/test_get_version_status.py
@@ -362,6 +362,20 @@ targets:
         self.assertEqual(target.get("scope"), [])
         self.assertEqual(target.get("exclude"), [])
 
+    def test_parse_scalar_scope_and_exclude(self):
+        """scope / exclude が同一行スカラー形式（リストでなく単一文字列）でも単一要素リストになる"""
+        yaml = """
+targets:
+  - name: doc-advisor
+    version_file: plugins/doc-advisor/.claude-plugin/plugin.json
+    version_path: version
+    scope: "plugins/doc-advisor/**"
+    exclude: "plugins/doc-advisor/**/*.md"
+"""
+        target = _parse_version_config_yaml(yaml)["targets"][0]
+        self.assertEqual(target["scope"], ["plugins/doc-advisor/**"])
+        self.assertEqual(target["exclude"], ["plugins/doc-advisor/**/*.md"])
+
 
 class TestGlobMatch(unittest.TestCase):
     """_pattern_to_regex / match_any_pattern のテスト"""
@@ -687,6 +701,28 @@ class TestNeedsBumpDetection(unittest.TestCase):
         self.assertEqual(forge["changed_file_count"], 1)
         self.assertFalse(anvil["files_changed"])
         self.assertEqual(output["summary"]["needs_bump"], ["forge"])
+
+    def test_needs_bump_detects_scalar_scope(self):
+        """scope がスカラー形式（`scope: "glob"`）でも needs_bump に検出される（Issue #26）"""
+        p = self.tmpdir / "plugins/doc-advisor/.claude-plugin/plugin.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"version": "0.1.0"}), encoding="utf-8")
+        (self.tmpdir / ".version-config.yaml").write_text(
+            "targets:\n"
+            "  - name: doc-advisor\n"
+            "    version_file: plugins/doc-advisor/.claude-plugin/plugin.json\n"
+            "    version_path: version\n"
+            "    scope: \"plugins/doc-advisor/**\"\n",
+            encoding="utf-8",
+        )
+        output = _run_main_with_mocks(
+            self.tmpdir,
+            lambda b, p: json.dumps({"version": "0.1.0"}),
+            mock_changed_files=["plugins/doc-advisor/scripts/foo.py"],
+        )
+        doc_advisor = next(t for t in output["targets"] if t["name"] == "doc-advisor")
+        self.assertTrue(doc_advisor["files_changed"])
+        self.assertEqual(output["summary"]["needs_bump"], ["doc-advisor"])
 
     def test_needs_bump_excludes_already_bumped(self):
         """既に bump 済み (changed=True) の target は needs_bump から除外する"""


### PR DESCRIPTION
## 概要

- `.version-config.yaml` の `scope`/`exclude` を同一行スカラー形式（例: `scope: "plugins/x/**"`）で記述すると、`get_version_status.py` の変更ファイル自動検出が常に不一致になっていたバグを修正

## 背景

`_parse_version_config_yaml()` は `scope:`/`exclude:` がそれ自身のみの行（リスト形式の開始）である場合にのみサブリストモードに入り、同一行にスカラー値を持つ形式（`scope: "plugins/x/**"`）は else 分岐に落ちて文字列のまま `current_target["scope"]` へ代入されていた。後続の `match_any_pattern` はこの文字列を1文字ずつパターンとしてイテレートするため、どのファイルパスにも一致せず `files_changed: false` / `summary.needs_bump: []` になっていた。

Closes #26

## やったこと

- `plugins/forge/scripts/get_version_status.py`: `_parse_version_config_yaml()` の scope/exclude スカラーキー処理に単一要素リスト正規化を追加
- `tests/forge/scripts/test_get_version_status.py`: スカラー形式のパース単体テスト + `needs_bump` 検出の統合テストを追加
- `plugins/forge/skills/update-version/SKILL.md`: `scope:`/`exclude:` がリスト形式・スカラー形式どちらでも解釈される旨を明記

## やらないこと（このプルリクエストのスコープ外とすること）

- 消費側（`match_any_pattern` 呼び出し元）での防御的 isinstance 正規化（パーサー層の1箇所修正で十分と判断）
- DES-023 §2.2 targets フィールド定義表への scope/exclude 追記（本バグとは無関係の既存ドキュメントギャップのため別件扱い）

## レビュー観点

- `_parse_version_config_yaml()` の分岐追加が既存のリスト形式パースを壊していないか（既存テスト61件 pass）

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- ~~Lv1: ぱっとみて違和感がないかチェックしてAcceptする~~
- Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## 備考

- `/forge:review code --auto`（agent-review backend）で承認済み（指摘0件）
- 全体テストスイート（1819件）・dprint チェックとも正常